### PR TITLE
Normalise GUID to HTTPS instead of HTTP

### DIFF
--- a/class-pushpress.php
+++ b/class-pushpress.php
@@ -104,7 +104,7 @@ class PuSHPress {
 			do_action( 'pushpress_topic_failure' );
 			if ( is_ssl() ) {
 				foreach ( $feed_urls as $k => $url )
-					$feed_urls[$k] = str_replace( 'https://', 'http://', $url );
+					$feed_urls[$k] = str_replace( 'http://', 'https://', $url );
 			}
 
 			$msg = 'hub_topic - ' . $_POST['hub_topic'];


### PR DESCRIPTION
fix https://github.com/Automattic/pushpress/issues/15
This plug-in is performing an hardcoded URL normalisation of GUIDs from `https://` to `http://`.
But the articles themselves in the corresponding RSS feeds have GUIDs using `https://`.
This leads to duplicate in clients subscribing to those feeds because articles exist with two different GUIDs:
https://github.com/FreshRSS/FreshRSS/issues/5151#issuecomment-3303107847
At the very least, the normalisation should be made the other way around, now that a majority of WordPress blogs run HTTPS, including WordPress.org, but a better approach would be desirable.
This PR does the minimal change of normalising to HTTPS instead of HTTP.
